### PR TITLE
Update mapr4 profile hbase version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1615,7 +1615,7 @@
       <properties>
         <hadoop.version>2.4.1-mapr-1408</hadoop.version>
         <yarn.version>2.4.1-mapr-1408</yarn.version>
-        <hbase.version>0.94.17-mapr-1405-4.0.0-FCS</hbase.version>
+        <hbase.version>0.98.4-mapr-1408</hbase.version>
         <zookeeper.version>3.4.5-mapr-1406</zookeeper.version>
       </properties>
       <dependencies>


### PR DESCRIPTION
The MAPr Maven repo http://repository.mapr.com/maven/ no longer (or never did) contain hbase `0.94.17-mapr-1405-4.0.0-FCS`.
This causes a build error to occur when building the examples module using the `mapr4` maven profile.

Updated the `mapr4` profile `hbase.version` to `0.98.4-mapr-1408`, which exists in the repository.

The following command now builds successfully:
     mvn -Pmapr4 package
